### PR TITLE
feat/#3/user-domain-setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/delivery/common/entity/Timestamped.java
+++ b/src/main/java/com/delivery/common/entity/Timestamped.java
@@ -1,0 +1,43 @@
+package com.delivery.common.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Timestamped {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private Long createdBy;
+
+    @LastModifiedDate
+    @Column
+    private LocalDateTime modifiedAt;
+
+    @LastModifiedBy
+    private Long modifiedBy;
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    @Column
+    private Long deletedBy;
+
+    public void markDeleted(Long userId) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = userId;
+    }
+}

--- a/src/main/java/com/delivery/config/JpaConfig.java
+++ b/src/main/java/com/delivery/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.delivery.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/delivery/user/entity/PublicStatus.java
+++ b/src/main/java/com/delivery/user/entity/PublicStatus.java
@@ -1,0 +1,5 @@
+package com.delivery.user.entity;
+
+public enum PublicStatus {
+    PUBLIC, PRIVATE
+}

--- a/src/main/java/com/delivery/user/entity/User.java
+++ b/src/main/java/com/delivery/user/entity/User.java
@@ -30,7 +30,7 @@ public class User extends Timestamped {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private PublicStatus publicStatus = PublicStatus.PUBLIC;;
+    private PublicStatus publicStatus = PublicStatus.PUBLIC;
 
     public User(String nickname, String email, String password) {
         this.nickname = nickname;

--- a/src/main/java/com/delivery/user/entity/User.java
+++ b/src/main/java/com/delivery/user/entity/User.java
@@ -1,0 +1,40 @@
+package com.delivery.user.entity;
+
+import com.delivery.common.entity.Timestamped;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Table(name = "p_user")
+@Getter
+public class User extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private UserRoleEnum role = UserRoleEnum.CUSTOMER;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PublicStatus publicStatus = PublicStatus.PUBLIC;;
+
+    public User(String nickname, String email, String password) {
+        this.nickname = nickname;
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/delivery/user/entity/UserRoleEnum.java
+++ b/src/main/java/com/delivery/user/entity/UserRoleEnum.java
@@ -1,0 +1,15 @@
+package com.delivery.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRoleEnum {
+    CUSTOMER("ROLE_CUSTOMER"),
+    OWNER("ROLE_OWNER"),
+    MANAGER("ROLE_MANAGER"),
+    MASTER("ROLE_MASTER");
+
+    private final String authority;
+}

--- a/src/main/java/com/delivery/user/repository/UserRepository.java
+++ b/src/main/java/com/delivery/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.delivery.user.repository;
+
+import com.delivery.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByNickname(String nickname);
+    boolean existsByEmail(String email);
+
+    Optional<User> findByNickname(String nickname);
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #3 

## 📝 개요
- User 도메인 구현
- JPA Auditing 활성화 및 공통 Entity 상속

## 🔁 변경 사항
- config.JpaConfig 추가
- common.entity.Timestamped 추가
- User Entity 생성
- UserRoleEnum 정의
- PulicStatus 정의
- UserRepository 생성

## 👀 참고 사항


## 👀 기타