### PR TITLE
Refactor/#18/common-response

### DIFF
--- a/src/main/java/com/delivery/common/ApiResponse.java
+++ b/src/main/java/com/delivery/common/ApiResponse.java
@@ -1,17 +1,17 @@
 package com.delivery.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL) //null 값일 경우 json 표현 안함
 public class ApiResponse<T> {
 
-    private final boolean success;
     private final String code;
     private final String message;
     private final T data;
 
-    private ApiResponse(boolean success, String code, String message, T data) {
-        this.success = success;
+    private ApiResponse(String code, String message, T data) {
         this.code = code;
         this.message = message;
         this.data = data;
@@ -19,11 +19,11 @@ public class ApiResponse<T> {
 
     // 성공 응답
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, "S000", "성공", data);
+        return new ApiResponse<>(null, null, data);
     }
 
     // 실패 응답
     public static <T> ApiResponse<T> error(String code, String message) {
-        return new ApiResponse<>(false, code, message, null);
+        return new ApiResponse<>(code, message, null);
     }
 }

--- a/src/main/java/com/delivery/config/SecurityConfig.java
+++ b/src/main/java/com/delivery/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
                         .requestMatchers("/").permitAll()
+                        .requestMatchers("/test/v1", "/test/error/v1").permitAll()
                         .requestMatchers("/api/v1/auth/signup").permitAll()
                         .requestMatchers("/api/v1/auth/login").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/delivery/test/TestController.java
+++ b/src/main/java/com/delivery/test/TestController.java
@@ -18,9 +18,6 @@ public class TestController {
 
     /**
      * @return {
-     * "success": true,
-     * "code": "S000",
-     * "message": "성공",
      * "data": "value"
      * }
      */
@@ -36,10 +33,8 @@ public class TestController {
 
     /**
      * @return {
-     * "success": false,
      * "code": "U002",
      * "message": "이미 가입된 이메일입니다.",
-     * "data": null
      * }
      */
     @GetMapping("/test/error/v1")

--- a/src/main/java/com/delivery/test/TestController.java
+++ b/src/main/java/com/delivery/test/TestController.java
@@ -18,17 +18,21 @@ public class TestController {
 
     /**
      * @return {
-     * "data": "value"
+     *   "data": {
+     *     "id": 1,
+     *     "value": "value",
+     *     "isNullField": null
+     *   }
      * }
      */
     @GetMapping("/test/v1")
-    public ResponseEntity<ApiResponse<String>> get() {
+    public ResponseEntity<ApiResponse<TestEntity>> get() {
 
         Long id = testService.save(new TestEntity("value"));
         TestEntity testEntity = testService.getTestEntity(id);
 
         System.out.println(testEntity.getValue());
-        return ResponseEntity.ok(ApiResponse.success(testEntity.getValue()));
+        return ResponseEntity.ok(ApiResponse.success(testEntity));
     }
 
     /**

--- a/src/main/java/com/delivery/test/TestEntity.java
+++ b/src/main/java/com/delivery/test/TestEntity.java
@@ -19,6 +19,8 @@ class TestEntity {
 
     private String value;
 
+    private String isNullField = null;
+
     public TestEntity(String value) {
         this.value = value;
     }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #18 

## 📝 개요
- common response 수정 
  - `@JsonInclude(JsonInclude.Include.NON_NULL) `를 이용
- 테스트 용 api security 허용

## 🔁 변경 사항
## 👀 참고 사항
```java
 /**
     * @return {
     *   "data": {
     *     "id": 1,
     *     "value": "value",
     *     "isNullField": null
     *   }
     * }
     */
    @GetMapping("/test/v1")
    public ResponseEntity<ApiResponse<TestEntity>> get() {

        Long id = testService.save(new TestEntity("value"));
        TestEntity testEntity = testService.getTestEntity(id);

        System.out.println(testEntity.getValue());
        return ResponseEntity.ok(ApiResponse.success(testEntity));
    }

    /**
     * @return {
     * "code": "U002",
     * "message": "이미 가입된 이메일입니다.",
     * }
     */
    @GetMapping("/test/error/v1")
    public ResponseEntity<?> getError() {

        throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
    }
```
## 👀 기타