### PR TITLE
feat/#29/create-ai-entity

### DIFF
--- a/src/main/java/com/delivery/domain/ai/entity/Ai.java
+++ b/src/main/java/com/delivery/domain/ai/entity/Ai.java
@@ -1,0 +1,44 @@
+package com.delivery.domain.ai.entity;
+
+import com.delivery.global.common.entity.Timestamped;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_ai")
+@Getter
+public class Ai extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID aiId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "menu_id", nullable = false)
+    private UUID menuId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "request_type", nullable = false)
+    private RequestTypeEnum requestTypeEnum = RequestTypeEnum.MENU_DESCRIPTION;
+
+    @Column(length = 500, nullable = false)
+    private String prompt;
+
+    private String response;
+
+    @Builder
+    public Ai(Long userId, UUID menuId, String prompt, String response) {
+        this.userId = userId;
+        this.menuId = menuId;
+        this.prompt = prompt;
+        this.response = response;
+    }
+}

--- a/src/main/java/com/delivery/domain/ai/entity/Ai.java
+++ b/src/main/java/com/delivery/domain/ai/entity/Ai.java
@@ -1,5 +1,6 @@
 package com.delivery.domain.ai.entity;
 
+import com.delivery.domain.user.entity.User;
 import com.delivery.global.common.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -17,26 +18,31 @@ public class Ai extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "ai_id", nullable = false)
     private UUID aiId;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    // 사용자 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
+    // 메뉴 (N:1) -> Menu 엔티티 생성 전까지 UUID로 보관
     @Column(name = "menu_id", nullable = false)
     private UUID menuId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "request_type", nullable = false)
-    private RequestTypeEnum requestTypeEnum = RequestTypeEnum.MENU_DESCRIPTION;
+    private RequestTypeEnum requestType = RequestTypeEnum.MENU_DESCRIPTION;
 
-    @Column(length = 500, nullable = false)
+    @Column(name = "prompt", nullable = false, length = 500)
     private String prompt;
 
+    @Column(name = "response")
     private String response;
 
     @Builder
-    public Ai(Long userId, UUID menuId, String prompt, String response) {
-        this.userId = userId;
+    public Ai(User user, UUID menuId, String prompt, String response) {
+        this.user = user;
         this.menuId = menuId;
         this.prompt = prompt;
         this.response = response;

--- a/src/main/java/com/delivery/domain/ai/entity/RequestTypeEnum.java
+++ b/src/main/java/com/delivery/domain/ai/entity/RequestTypeEnum.java
@@ -1,0 +1,5 @@
+package com.delivery.domain.ai.entity;
+
+public enum RequestTypeEnum {
+    MENU_DESCRIPTION
+}

--- a/src/main/java/com/delivery/domain/ai/repository/AiRepository.java
+++ b/src/main/java/com/delivery/domain/ai/repository/AiRepository.java
@@ -1,0 +1,9 @@
+package com.delivery.domain.ai.repository;
+
+import com.delivery.domain.ai.entity.Ai;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AiRepository extends JpaRepository<Ai, UUID> {
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #29 

## 📝 개요
- AI 요청/응답 기록을 위한 `Ai` 엔티티, `AiRepository`, `RequestTypeEnum`을 생성했습니다.

## 🔁 변경 사항
- `Ai` 엔티티 추가 (`p_ai` 테이블 매핑)
- `AiRepository` 추가
- `RequestTypeEnum` 정의 (`MENU_DESCRIPTION`)

## 👀 참고 사항
- 현재 `Menu` 엔티티가 없어 `menu_id`를 UUID 컬럼으로 임시 보관합니다.  
- 추후 `Menu` 엔티티 생성 시 `@ManyToOne` 매핑으로 리팩터링 예정입니다.  

## 👀 기타