### PR TITLE
feat/#39/create-review-entity

### DIFF
--- a/src/main/java/com/delivery/domain/review/entity/Review.java
+++ b/src/main/java/com/delivery/domain/review/entity/Review.java
@@ -1,0 +1,55 @@
+package com.delivery.domain.review.entity;
+
+import com.delivery.domain.order.entity.Order;
+import com.delivery.domain.user.entity.User;
+import com.delivery.global.common.entity.Timestamped;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_review")
+@Getter
+public class Review extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "review_id", nullable = false)
+    private UUID reviewId;
+
+    // 작성자 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) // 필요할 때만 로딩
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 가게 (N:1) -> Store 엔티티 생성 전까지 UUID로 보관
+    @Column(name = "store_id", nullable = false)
+    private UUID storeId;
+
+    // 주문 (1:1) — 주문당 리뷰 1건
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_id", unique = true, nullable = false)
+    private Order order;
+
+    // 평점 (1~5)
+    @Column(name = "rating", nullable = false)
+    private int rating;
+
+    // 리뷰 내용
+    @Column(name = "content", length = 500)
+    private String content;
+
+    @Builder
+    private Review(User user, UUID storeId, Order order, int rating, String content) {
+        this.user = user;
+        this.storeId = storeId;
+        this.order = order;
+        this.rating = rating;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/delivery/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/delivery/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package com.delivery.domain.review.repository;
+
+import com.delivery.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ReviewRepository extends JpaRepository<Review, UUID> {
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #39 

## 📝 개요
- Review 도메인의 Entity 및 Repository를 생성했습니다.

## 🔁 변경 사항
- `Review` 엔티티 추가  (p_review 테이블 매핑)
- `ReviewRepository` 추가

## 👀 참고 사항
- 현재 `Store` 엔티티가 없어 `store_id`를 UUID 컬럼으로 임시 보관합니다.  
- 추후 `Store` 엔티티 생성 시 `@ManyToOne` 매핑으로 리팩터링 예정입니다.

## 👀 기타