### PR TITLE
Feat/#49/cookie auth

### DIFF
--- a/src/main/java/com/delivery/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/delivery/domain/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.delivery.domain.auth.controller;
 
 import com.delivery.domain.auth.dto.SignUpRequestDto;
-import com.delivery.domain.auth.service.AuthService;
+import com.delivery.domain.auth.service.AuthServiceImpl;
 import com.delivery.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,10 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final AuthService authService;
+    private final AuthServiceImpl authService;
 
     @PostMapping("/signup")
-    public ResponseEntity signup(@RequestBody SignUpRequestDto signUpRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> signup(@RequestBody SignUpRequestDto signUpRequestDto) {
         authService.signup(signUpRequestDto);
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/src/main/java/com/delivery/domain/auth/service/AuthService.java
+++ b/src/main/java/com/delivery/domain/auth/service/AuthService.java
@@ -1,33 +1,7 @@
 package com.delivery.domain.auth.service;
 
 import com.delivery.domain.auth.dto.SignUpRequestDto;
-import com.delivery.global.exception.BusinessException;
-import com.delivery.global.exception.ErrorCode;
-import com.delivery.domain.user.entity.User;
-import com.delivery.domain.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-public class AuthService {
-
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
-
-    public void signup(SignUpRequestDto signUpRequestDto) {
-        if(userRepository.existsByNickname(signUpRequestDto.getNickname())){
-            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
-        }
-
-        if (userRepository.existsByEmail(signUpRequestDto.getEmail())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
-        }
-
-        String encodedPassword = passwordEncoder.encode(signUpRequestDto.getPassword());
-
-        User user = new User(signUpRequestDto.getNickname(), signUpRequestDto.getEmail(), encodedPassword);
-        userRepository.save(user);
-    }
+public interface AuthService {
+    void signup(SignUpRequestDto signUpRequestDto);
 }

--- a/src/main/java/com/delivery/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/delivery/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,33 @@
+package com.delivery.domain.auth.service;
+
+import com.delivery.domain.auth.dto.SignUpRequestDto;
+import com.delivery.global.exception.BusinessException;
+import com.delivery.global.exception.ErrorCode;
+import com.delivery.domain.user.entity.User;
+import com.delivery.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signup(SignUpRequestDto signUpRequestDto) {
+        if(userRepository.existsByNickname(signUpRequestDto.getNickname())){
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        if (userRepository.existsByEmail(signUpRequestDto.getEmail())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        String encodedPassword = passwordEncoder.encode(signUpRequestDto.getPassword());
+
+        User user = new User(signUpRequestDto.getNickname(), signUpRequestDto.getEmail(), encodedPassword);
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/com/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/delivery/domain/user/repository/UserRepository.java
@@ -9,6 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
 
-    Optional<User> findByNickname(String kickname);
+    Optional<User> findByNickname(String nickname);
     Optional<User> findByUserId(Long userId);
 }

--- a/src/main/java/com/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/delivery/domain/user/repository/UserRepository.java
@@ -9,5 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
 
-    Optional<User> findByNickname(String nickname);
+    Optional<User> findByNickname(String kickname);
+    Optional<User> findByUserId(Long userId);
 }

--- a/src/main/java/com/delivery/global/config/SecurityConfig.java
+++ b/src/main/java/com/delivery/global/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -45,6 +46,10 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthorizationFilter jwtAuthorizationFilter, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http.csrf((csrf) -> csrf.disable());
+
+        http.sessionManagement((session) ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
 
         //추후 경로 추가, ex) .requestMatchers("/stores/**", "/menus/**").hasRole("OWNER")
         http.authorizeHttpRequests((authorizeHttpRequests) ->

--- a/src/main/java/com/delivery/global/jwt/JwtUtil.java
+++ b/src/main/java/com/delivery/global/jwt/JwtUtil.java
@@ -5,21 +5,18 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
-import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
 
 @Component
 public class JwtUtil {
 
-    public static final String AUTHORIZATION_HEADER = "Authorization";
-    public static final String BEARER_PREFIX = "Bearer ";
     public static final String AUTHORIZATION_KEY = "auth";
     public static final long EXPIRE_TIME = 30 * 60 * 1000L;
 
@@ -33,22 +30,30 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(String username, UserRoleEnum role){
+    public String createToken(Long userId, String username, UserRoleEnum role){
         Date date = new Date();
 
         return Jwts.builder()
-                .subject(username)
+                .subject(String.valueOf(userId))
+                .claim("nickname", username)
                 .claim(AUTHORIZATION_KEY, role.getAuthority())
                 .expiration(new Date(date.getTime() + EXPIRE_TIME))
                 .signWith(key)
                 .compact();
     }
 
-    public String getJwtFromHeader(HttpServletRequest request) {
-        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(BEARER_PREFIX.length());
+    public String getJwtFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
         }
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("accessToken".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+
         return null;
     }
 

--- a/src/main/java/com/delivery/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/delivery/global/security/CustomUserDetailsService.java
@@ -1,0 +1,8 @@
+package com.delivery.global.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+public interface CustomUserDetailsService extends UserDetailsService {
+    UserDetails loadUserByUserId(Long userId);
+}

--- a/src/main/java/com/delivery/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/delivery/global/security/JwtAuthenticationFilter.java
@@ -1,15 +1,17 @@
 package com.delivery.global.security;
 
 import com.delivery.domain.auth.dto.LoginRequestDto;
+import com.delivery.domain.user.entity.UserRoleEnum;
 import com.delivery.global.common.ApiResponse;
 import com.delivery.global.exception.BusinessException;
 import com.delivery.global.exception.ErrorCode;
 import com.delivery.global.jwt.JwtUtil;
-import com.delivery.domain.user.entity.UserRoleEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -51,15 +53,20 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
-        String nickname = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
-        UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+        UserDetailsImpl userDetails = (UserDetailsImpl) authResult.getPrincipal();
 
-        String token = jwtUtil.createToken(nickname, role);
+        Long userId = userDetails.getUserId();
+        String nickname = userDetails.getUsername();
+        UserRoleEnum role = userDetails.getRole();
+
+        String accessToken = jwtUtil.createToken(userId, nickname, role);
+
+        addAccessTokenToCookie(response, accessToken);
 
         Map<String, Object> data = new HashMap<>();
+        data.put("userId", userId);
         data.put("nickname", nickname);
         data.put("role", role.getAuthority());
-        data.put("token", token);
 
         ApiResponse<?> apiResponse = ApiResponse.success(data);
         writeResponse(response, apiResponse);
@@ -76,5 +83,17 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         objectMapper.writeValue(response.getWriter(), apiResponse);
+    }
+
+    private void addAccessTokenToCookie(HttpServletResponse response, String token) {
+        ResponseCookie cookie = ResponseCookie.from("accessToken", token)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Lax")
+                .maxAge(30 * 60)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/src/main/java/com/delivery/global/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/delivery/global/security/JwtAuthorizationFilter.java
@@ -15,7 +15,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -25,18 +24,18 @@ import java.io.IOException;
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
-    private final UserDetailsService userDetailsService;
+    private final CustomUserDetailsService userDetailsService;
 
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String token = jwtUtil.getJwtFromHeader(request);
+        String token = jwtUtil.getJwtFromCookie(request);
 
         if (StringUtils.hasText(token)) {
             try {
                 jwtUtil.validateToken(token);
                 Claims userInfo = jwtUtil.getUserInfoFromToken(token);
-                setAuthentication(userInfo.getSubject());
+                setAuthentication(Long.valueOf(userInfo.getSubject()));
             } catch (JwtException e) {
                 throw new BusinessException(ErrorCode.INVALID_TOKEN);
             } catch (Exception e) {
@@ -47,16 +46,16 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    public void setAuthentication(String nickname) {
+    public void setAuthentication(Long userId) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        Authentication authentication = createAuthentication(nickname);
+        Authentication authentication = createAuthentication(userId);
         context.setAuthentication(authentication);
 
         SecurityContextHolder.setContext(context);
     }
 
-    private Authentication createAuthentication(String nickname) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(nickname);
+    private Authentication createAuthentication(Long userId) {
+        UserDetails userDetails = userDetailsService.loadUserByUserId(userId);
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/delivery/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/delivery/global/security/UserDetailsImpl.java
@@ -1,6 +1,7 @@
 package com.delivery.global.security;
 
 import com.delivery.domain.user.entity.User;
+import com.delivery.domain.user.entity.UserRoleEnum;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -10,7 +11,7 @@ import java.util.List;
 
 public class UserDetailsImpl implements UserDetails {
 
-    private User user;
+    private final User user;
 
     public UserDetailsImpl(User user) {
         this.user = user;
@@ -18,6 +19,14 @@ public class UserDetailsImpl implements UserDetails {
 
     public User getUser() {
         return user;
+    }
+
+    public Long getUserId() {
+        return user.getUserId();
+    }
+
+    public UserRoleEnum getRole() {
+        return user.getRole();
     }
 
     @Override

--- a/src/main/java/com/delivery/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/delivery/global/security/UserDetailsServiceImpl.java
@@ -24,7 +24,7 @@ public class UserDetailsServiceImpl implements CustomUserDetailsService {
     }
 
     public UserDetails loadUserByUserId(Long userId) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         return new UserDetailsImpl(user);

--- a/src/main/java/com/delivery/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/delivery/global/security/UserDetailsServiceImpl.java
@@ -1,24 +1,30 @@
 package com.delivery.global.security;
 
-import com.delivery.global.exception.BusinessException;
-import com.delivery.global.exception.ErrorCode;
 import com.delivery.domain.user.entity.User;
 import com.delivery.domain.user.repository.UserRepository;
+import com.delivery.global.exception.BusinessException;
+import com.delivery.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class UserDetailsServiceImpl implements UserDetailsService {
+public class UserDetailsServiceImpl implements CustomUserDetailsService {
 
     private final UserRepository userRepository;
 
     @Override
     public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
         User user = userRepository.findByNickname(nickname)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return new UserDetailsImpl(user);
+    }
+
+    public UserDetails loadUserByUserId(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         return new UserDetailsImpl(user);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #49

## 📝 개요
- 기존에는 로그인 성공시 AccessToken을 responseBody에 반환 쿠키 옵션을 사용해 보안을 강화하기 위해 쿠키에 저장하도록 변경
- 인가 부분도 같이 쿠키에 담긴 AccessToken을 이용해 인증하도록 변경

## 🔁 변경 사항
- 로그인 성공 시 Access Token을 Cookie에 담아 응답하도록 변경
- JwtAuthorizationFilter(Header 기반 인증 -> Cookie 기반 인증)
- SecurityConfig에서 세션 비활성화 설정
- JWT subject를 nickname -> userId 기반으로 변경
- AuthService를 interface + 구현체 구조로 분리

## 👀 참고 사항
- 토큰 전달 방식을 Cookie 기반으로 변경해서 테스트 시 쿠키 방식으로 인증 확인 부탁드립니다!

## 👀 기타