### PR TITLE
feature/get order list by owner

### DIFF
--- a/src/main/java/com/delivery/domain/order/controller/OrderController.java
+++ b/src/main/java/com/delivery/domain/order/controller/OrderController.java
@@ -6,12 +6,15 @@ import com.delivery.global.security.UserDetailsImpl;
 import com.delivery.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +27,13 @@ public class OrderController {
         User user = userDetails.getUser();
         List<OrderResponseDto.OrderListDto> list = orderService.getOrderList(user.getUserId());
         return ResponseEntity.ok(list);
+    }
+
+    @PreAuthorize("hasRole('OWNER')")
+    @GetMapping("/owner")
+    public ResponseEntity<?> getOwnerOrders(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        User user = userDetails.getUser();
+        // 추후 store -> 수정 (현재는 사장이 로그인했다고 가정하고 ID로 찾음)
+        return ResponseEntity.ok(orderService.getOrdersByOwner(user.getUserId()));
     }
 }

--- a/src/main/java/com/delivery/domain/order/entity/Order.java
+++ b/src/main/java/com/delivery/domain/order/entity/Order.java
@@ -35,6 +35,10 @@ public class Order extends Timestamped {
 
     // Store 추가 필요
 
+    // 임시로 추가 -> 추후 Store과 연결
+    @Column(nullable = false)
+    private Long ownerId;
+
     @OneToMany(mappedBy = "order")
     private List<OrderMenu> orderMenus = new ArrayList<>();
 }

--- a/src/main/java/com/delivery/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/delivery/domain/order/repository/OrderRepository.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
     List<Order> findByUser_UserId(Long userId);
+    List<Order> findByOwnerId(Long ownerId);
 }

--- a/src/main/java/com/delivery/domain/order/service/OrderService.java
+++ b/src/main/java/com/delivery/domain/order/service/OrderService.java
@@ -1,9 +1,13 @@
 package com.delivery.domain.order.service;
 
 import com.delivery.domain.order.dto.OrderResponseDto;
+import com.delivery.domain.order.entity.Order;
+import com.delivery.domain.user.entity.User;
 
 import java.util.List;
 
 public interface OrderService {
     List<OrderResponseDto.OrderListDto> getOrderList(Long userId);
+    // 수정 필요
+    List<OrderResponseDto.OrderListDto> getOrdersByOwner(Long ownerId);
 }

--- a/src/main/java/com/delivery/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/delivery/domain/order/service/OrderServiceImpl.java
@@ -20,4 +20,13 @@ public class OrderServiceImpl implements OrderService {
                 .map(OrderResponseDto.OrderListDto::from)
                 .toList();
     }
+
+    @Override
+    public List<OrderResponseDto.OrderListDto> getOrdersByOwner(Long ownerId) {
+        // 수정 필요
+        List<Order> orders = orderRepository.findByOwnerId(ownerId);
+        return orders.stream()
+                .map(OrderResponseDto.OrderListDto::from)
+                .toList();
+    }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #62 

## 📝 개요
- OWNER 권한을 가진 유저가 자신의 가게의 모든 주문 목록을 조회합니다.
- 현재는 ownerId를 사용했습니다. 추후 Store와 Menu를 활용해 수정하도록 하겠습니다.

## 🔁 변경 사항
- 변경 사항을 작성해주세요.

## 👀 참고 사항
- 현재는 주문자와 사장이 받고 있는 주문 정보가 같은데, 주문자만 알아야 할 정보/사장만 알아야 할 정보가 나뉘어져 있다면 뭐가 있을까요,,, 주문자 주소는 사장에게 노출해야 할지 말아야 할지 고민중이라 편히 말씀주시면 감사하겠습니다!

## 👀 기타