### PR TITLE
feat/#82/delete-review-api

### DIFF
--- a/src/main/java/com/delivery/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/delivery/domain/review/controller/ReviewController.java
@@ -41,6 +41,22 @@ public class ReviewController {
     }
 
     /**
+     * 리뷰 조회
+     * - CUSTOMER(작성자 본인), OWNER(본인 가게), MANAGER, MASTER 접근 가능
+     * - 삭제되지 않은 리뷰만 조회
+     */
+    @GetMapping("/{reviewId}")
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<ReviewRes>> getReview(
+            @PathVariable UUID reviewId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        ReviewRes response = reviewService.getReview(userDetails.getUserId(), userDetails.getRole(), reviewId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
      * 리뷰 수정
      * - 작성자 본인만 수정 가능 (CUSTOMER만 허용)
      * - 수정 가능 필드: content, rating

--- a/src/main/java/com/delivery/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/delivery/domain/review/controller/ReviewController.java
@@ -13,6 +13,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/api/v1/reviews")
 @RequiredArgsConstructor
@@ -32,8 +34,24 @@ public class ReviewController {
             @Valid @RequestBody ReviewCreateReq request,
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
-        ReviewRes response = reviewService.createReview(userDetails.getUser().getUserId(), request);
+        ReviewRes response = reviewService.createReview(userDetails.getUserId(), request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 리뷰 삭제 (Soft Delete)
+     * - CUSTOMER: 본인이 작성한 리뷰만 삭제 가능
+     * - MANAGER/MASTER: 모든 리뷰 삭제 가능
+     */
+    @DeleteMapping("/{reviewId}")
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'MANAGER', 'MASTER')")
+    public ResponseEntity<Void> deleteReview(
+            @PathVariable UUID reviewId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        reviewService.deleteReview(userDetails.getUserId(), userDetails.getRole(), reviewId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/delivery/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/delivery/domain/review/controller/ReviewController.java
@@ -2,6 +2,7 @@ package com.delivery.domain.review.controller;
 
 import com.delivery.domain.review.dto.ReviewCreateReq;
 import com.delivery.domain.review.dto.ReviewRes;
+import com.delivery.domain.review.dto.ReviewUpdateReq;
 import com.delivery.domain.review.service.ReviewService;
 import com.delivery.global.common.ApiResponse;
 import com.delivery.global.security.service.UserDetailsImpl;
@@ -37,6 +38,23 @@ public class ReviewController {
         ReviewRes response = reviewService.createReview(userDetails.getUserId(), request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 리뷰 수정
+     * - 작성자 본인만 수정 가능 (CUSTOMER만 허용)
+     * - 수정 가능 필드: content, rating
+     */
+    @PutMapping("/{reviewId}")
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
+    public ResponseEntity<ApiResponse<ReviewRes>> updateReview(
+            @PathVariable UUID reviewId,
+            @Valid @RequestBody ReviewUpdateReq request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        ReviewRes response = reviewService.updateReview(userDetails.getUserId(), reviewId, request);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**

--- a/src/main/java/com/delivery/domain/review/dto/ReviewUpdateReq.java
+++ b/src/main/java/com/delivery/domain/review/dto/ReviewUpdateReq.java
@@ -1,0 +1,20 @@
+package com.delivery.domain.review.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewUpdateReq {
+
+    @NotNull(message = "평점은 필수입니다.")
+    @Min(value = 1, message = "평점은 최소 1점입니다.")
+    @Max(value = 5, message = "평점은 최대 5점입니다.")
+    private int rating;
+
+    @NotBlank(message = "리뷰 내용은 필수입니다.")
+    @Size(min = 10, max = 500, message = "리뷰 내용은 10자 이상 500자 이하로 입력해야 합니다.")
+    private String content;
+}

--- a/src/main/java/com/delivery/domain/review/entity/Review.java
+++ b/src/main/java/com/delivery/domain/review/entity/Review.java
@@ -52,4 +52,14 @@ public class Review extends Timestamped {
         this.rating = rating;
         this.content = content;
     }
+
+    /**
+     * 리뷰 수정
+     * @param rating 평점 (1~5)
+     * @param content 리뷰 내용
+     */
+    public void update(int rating, String content) {
+        this.rating = rating;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/delivery/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/delivery/domain/review/repository/ReviewRepository.java
@@ -2,11 +2,27 @@ package com.delivery.domain.review.repository;
 
 import com.delivery.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
-    // 주문별 리뷰 존재 여부 확인
+    // 주문 ID로 삭제되지 않은 리뷰 존재 여부 확인
     boolean existsByOrder_OrderIdAndDeletedAtIsNull(UUID orderId);
+
+    // 리뷰 ID로 삭제되지 않은 리뷰 조회
+    Optional<Review> findByReviewIdAndDeletedAtIsNull(UUID reviewId);
+
+    /**
+     * 리뷰 ID로 조회 (삭제되지 않은 리뷰만, User JOIN FETCH)
+     * N+1 문제 방지를 위해 User 정보를 함께 조회
+     */
+    @Query("SELECT r FROM Review r " +
+            "JOIN FETCH r.user " +
+            "WHERE r.reviewId = :reviewId " +
+            "AND r.deletedAt IS NULL")
+    Optional<Review> findByReviewIdWithUser(@Param("reviewId") UUID reviewId);
 }

--- a/src/main/java/com/delivery/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/delivery/domain/review/repository/ReviewRepository.java
@@ -17,12 +17,24 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     Optional<Review> findByReviewIdAndDeletedAtIsNull(UUID reviewId);
 
     /**
-     * 리뷰 ID로 조회 (삭제되지 않은 리뷰만, User JOIN FETCH)
-     * N+1 문제 방지를 위해 User 정보를 함께 조회
+     * 리뷰 조회 (User 정보 함께 조회)
+     * - 삭제되지 않은 리뷰만 조회
      */
     @Query("SELECT r FROM Review r " +
             "JOIN FETCH r.user " +
             "WHERE r.reviewId = :reviewId " +
             "AND r.deletedAt IS NULL")
     Optional<Review> findByReviewIdWithUser(@Param("reviewId") UUID reviewId);
+
+    /**
+     * 리뷰 조회 (User, Order 정보 함께 조회)
+     * - 삭제되지 않은 리뷰만 조회
+     */
+    @Query("SELECT r FROM Review r " +
+            "JOIN FETCH r.user " +
+            "JOIN FETCH r.order " +
+            "WHERE r.reviewId = :reviewId " +
+            "AND r.deletedAt IS NULL")
+    Optional<Review> findByReviewIdWithUserAndOrder(@Param("reviewId") UUID reviewId);
+
 }

--- a/src/main/java/com/delivery/domain/review/service/ReviewService.java
+++ b/src/main/java/com/delivery/domain/review/service/ReviewService.java
@@ -2,9 +2,15 @@ package com.delivery.domain.review.service;
 
 import com.delivery.domain.review.dto.ReviewCreateReq;
 import com.delivery.domain.review.dto.ReviewRes;
+import com.delivery.domain.user.entity.UserRoleEnum;
+
+import java.util.UUID;
 
 public interface ReviewService {
 
     // 리뷰 생성
     ReviewRes createReview(Long userId, ReviewCreateReq request);
+
+    // 리뷰 삭제 (Soft Delete)
+    void deleteReview(Long userId, UserRoleEnum role, UUID reviewId);
 }

--- a/src/main/java/com/delivery/domain/review/service/ReviewService.java
+++ b/src/main/java/com/delivery/domain/review/service/ReviewService.java
@@ -2,6 +2,7 @@ package com.delivery.domain.review.service;
 
 import com.delivery.domain.review.dto.ReviewCreateReq;
 import com.delivery.domain.review.dto.ReviewRes;
+import com.delivery.domain.review.dto.ReviewUpdateReq;
 import com.delivery.domain.user.entity.UserRoleEnum;
 
 import java.util.UUID;
@@ -10,6 +11,9 @@ public interface ReviewService {
 
     // 리뷰 생성
     ReviewRes createReview(Long userId, ReviewCreateReq request);
+
+    // 리뷰 수정
+    ReviewRes updateReview(Long userId, UUID reviewId, ReviewUpdateReq request);
 
     // 리뷰 삭제 (Soft Delete)
     void deleteReview(Long userId, UserRoleEnum role, UUID reviewId);

--- a/src/main/java/com/delivery/domain/review/service/ReviewService.java
+++ b/src/main/java/com/delivery/domain/review/service/ReviewService.java
@@ -12,6 +12,9 @@ public interface ReviewService {
     // 리뷰 생성
     ReviewRes createReview(Long userId, ReviewCreateReq request);
 
+    // 리뷰 조회
+    ReviewRes getReview(Long userId, UserRoleEnum role, UUID reviewId);
+
     // 리뷰 수정
     ReviewRes updateReview(Long userId, UUID reviewId, ReviewUpdateReq request);
 

--- a/src/main/java/com/delivery/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/delivery/domain/review/service/ReviewServiceImpl.java
@@ -8,7 +8,9 @@ import com.delivery.domain.review.dto.ReviewRes;
 import com.delivery.domain.review.entity.Review;
 import com.delivery.domain.review.repository.ReviewRepository;
 import com.delivery.domain.user.entity.User;
+import com.delivery.domain.user.entity.UserRoleEnum;
 import com.delivery.domain.user.repository.UserRepository;
+import com.delivery.domain.user.service.UserService;
 import com.delivery.global.exception.BusinessException;
 import com.delivery.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,7 @@ public class ReviewServiceImpl implements ReviewService{
     private final ReviewRepository reviewRepository;
     private final OrderRepository orderRepository;  // TODO(#68): OrderService로 교체
     private final UserRepository userRepository;    // TODO(#68): UserService로 교체
+    private final UserService userService;
 
     // 리뷰 생성
     @Override
@@ -65,6 +68,65 @@ public class ReviewServiceImpl implements ReviewService{
                 user.getNickname()
         );
     }
+
+    // 리뷰 삭제 (Soft Delete)
+    @Override
+    @Transactional
+    public void deleteReview(Long userId, UserRoleEnum role, UUID reviewId) {
+        log.info("[REVIEW] 삭제 요청 - userId: {}, role: {}, reviewId: {}", userId, role, reviewId);
+
+        // 리뷰 조회 (User 정보와 함께 조회 (JOIN FETCH))
+        Review review = getReviewWithUser(reviewId);
+
+        // 권한 검증
+        validateDeletePermission(userId, role, review);
+
+        // Soft Delete 처리
+        review.markDeleted(userId);
+
+        log.info("[REVIEW] 삭제 완료 - reviewId: {}, deletedBy: {}", reviewId, userId);
+    }
+
+    // 리뷰 조회 (삭제되지 않은 리뷰만, User 정보 함께 조회)
+    private Review getReviewWithUser(UUID reviewId) {
+        return reviewRepository.findByReviewIdWithUser(reviewId)
+                .orElseThrow(() -> {
+                    log.warn("[REVIEW] 리뷰 조회 실패 - reviewId: {}", reviewId);
+                    return new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
+                });
+    }
+
+    // 리뷰 조회 (삭제되지 않은 리뷰만)
+    private Review getReviewById(UUID reviewId) {
+        return reviewRepository.findByReviewIdAndDeletedAtIsNull(reviewId)
+                .orElseThrow(() -> {
+                    log.warn("[REVIEW] 리뷰 조회 실패 - reviewId: {}", reviewId);
+                    return new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
+                });
+    }
+
+    /**
+     * 삭제 권한 검증
+     * - MANAGER/MASTER: 모든 리뷰 삭제 가능
+     * - CUSTOMER: 본인 리뷰만 삭제 가능
+     */
+    private void validateDeletePermission(Long userId, UserRoleEnum role, Review review) {
+        // 관리자는 모든 리뷰 삭제 가능
+        if (role == UserRoleEnum.MANAGER || role == UserRoleEnum.MASTER) {
+            log.debug("[REVIEW] 관리자 권한으로 삭제 - userId: {}, role: {}", userId, role);
+            return;
+        }
+
+        // 일반 사용자는 본인 리뷰만 삭제 가능
+        if (!review.getUser().getUserId().equals(userId)) {
+            log.warn("[REVIEW] 권한 없음 - userId: {}, reviewOwnerId: {}",
+                    userId, review.getUser().getUserId());
+            throw new BusinessException(ErrorCode.REVIEW_DELETE_FORBIDDEN);
+        }
+
+        log.debug("[REVIEW] 본인 리뷰 삭제 - userId: {}", userId);
+    }
+
 
     // 리뷰 저장
     private Review saveReview(User user, Order order, Long storeId, int rating, String content) {

--- a/src/main/java/com/delivery/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/delivery/domain/review/service/ReviewServiceImpl.java
@@ -5,6 +5,7 @@ import com.delivery.domain.order.entity.OrderStatus;
 import com.delivery.domain.order.repository.OrderRepository;
 import com.delivery.domain.review.dto.ReviewCreateReq;
 import com.delivery.domain.review.dto.ReviewRes;
+import com.delivery.domain.review.dto.ReviewUpdateReq;
 import com.delivery.domain.review.entity.Review;
 import com.delivery.domain.review.repository.ReviewRepository;
 import com.delivery.domain.user.entity.User;
@@ -69,6 +70,43 @@ public class ReviewServiceImpl implements ReviewService{
         );
     }
 
+    @Override
+    @Transactional
+    public ReviewRes updateReview(Long userId, UUID reviewId, ReviewUpdateReq request) {
+        log.info("[REVIEW] 수정 요청 - reviewId: {}, userId: {}", reviewId, userId);
+
+        // 리뷰 조회 (User, Order 정보와 함께 조회)
+        Review review = getReviewWithUserAndOrder(reviewId);
+
+        // 작성자 본인 검증 (CUSTOMER만 수정 가능)
+        validateUpdatePermission(userId, review);
+
+        // 리뷰 수정
+        review.update(request.getRating(), request.getContent());
+
+        log.info("[REVIEW] 수정 완료 - reviewId: {}, rating: {}", reviewId, request.getRating());
+        return ReviewRes.from(
+                review,
+                review.getOrder().getOrderId(),
+                review.getUser().getUserId(),
+                review.getUser().getNickname()
+        );
+    }
+
+    /**
+     * 수정 권한 검증
+     * - 작성자 본인만 수정 가능 (CUSTOMER만 허용)
+     */
+    private void validateUpdatePermission(Long userId, Review review) {
+        if (!review.getUser().getUserId().equals(userId)) {
+            log.warn("[REVIEW] 수정 권한 없음 - userId: {}, reviewOwnerId: {}",
+                    userId, review.getUser().getUserId());
+            throw new BusinessException(ErrorCode.REVIEW_UPDATE_FORBIDDEN);
+        }
+
+        log.debug("[REVIEW] 본인 리뷰 수정 - userId: {}", userId);
+    }
+
     // 리뷰 삭제 (Soft Delete)
     @Override
     @Transactional
@@ -85,24 +123,6 @@ public class ReviewServiceImpl implements ReviewService{
         review.markDeleted(userId);
 
         log.info("[REVIEW] 삭제 완료 - reviewId: {}, deletedBy: {}", reviewId, userId);
-    }
-
-    // 리뷰 조회 (삭제되지 않은 리뷰만, User 정보 함께 조회)
-    private Review getReviewWithUser(UUID reviewId) {
-        return reviewRepository.findByReviewIdWithUser(reviewId)
-                .orElseThrow(() -> {
-                    log.warn("[REVIEW] 리뷰 조회 실패 - reviewId: {}", reviewId);
-                    return new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
-                });
-    }
-
-    // 리뷰 조회 (삭제되지 않은 리뷰만)
-    private Review getReviewById(UUID reviewId) {
-        return reviewRepository.findByReviewIdAndDeletedAtIsNull(reviewId)
-                .orElseThrow(() -> {
-                    log.warn("[REVIEW] 리뷰 조회 실패 - reviewId: {}", reviewId);
-                    return new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
-                });
     }
 
     /**
@@ -127,6 +147,32 @@ public class ReviewServiceImpl implements ReviewService{
         log.debug("[REVIEW] 본인 리뷰 삭제 - userId: {}", userId);
     }
 
+    // 리뷰 조회 (삭제되지 않은 리뷰만, User 정보 함께 조회)
+    private Review getReviewWithUser(UUID reviewId) {
+        return reviewRepository.findByReviewIdWithUser(reviewId)
+                .orElseThrow(() -> {
+                    log.warn("[REVIEW] 리뷰 조회 실패 - reviewId: {}", reviewId);
+                    return new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
+                });
+    }
+
+    // 리뷰 조회 (삭제되지 않은 리뷰만, User, Order 정보 함께 조회)
+    private Review getReviewWithUserAndOrder(UUID reviewId) {
+        return reviewRepository.findByReviewIdWithUserAndOrder(reviewId)
+                .orElseThrow(() -> {
+                    log.warn("[REVIEW] 리뷰 조회 실패 - reviewId: {}", reviewId);
+                    return new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
+                });
+    }
+
+    // 리뷰 조회 (삭제되지 않은 리뷰만)
+    private Review getReviewById(UUID reviewId) {
+        return reviewRepository.findByReviewIdAndDeletedAtIsNull(reviewId)
+                .orElseThrow(() -> {
+                    log.warn("[REVIEW] 리뷰 조회 실패 - reviewId: {}", reviewId);
+                    return new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
+                });
+    }
 
     // 리뷰 저장
     private Review saveReview(User user, Order order, Long storeId, int rating, String content) {

--- a/src/main/java/com/delivery/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/delivery/domain/review/service/ReviewServiceImpl.java
@@ -70,6 +70,58 @@ public class ReviewServiceImpl implements ReviewService{
         );
     }
 
+    // 리뷰 조회
+    @Override
+    public ReviewRes getReview(Long userId, UserRoleEnum role, UUID reviewId) {
+        log.info("[REVIEW] 조회 요청 - reviewId: {}, userId: {}, role: {}", reviewId, userId, role);
+
+        // 리뷰 조회 (User, Order 정보와 함께 조회)
+        Review review = getReviewWithUserAndOrder(reviewId);
+
+        // 접근 권한 검증
+        validateReadPermission(userId, role, review);
+
+        log.info("[REVIEW] 조회 완료 - reviewId: {}", reviewId);
+        return ReviewRes.from(
+                review,
+                review.getOrder().getOrderId(),
+                review.getUser().getUserId(),
+                review.getUser().getNickname()
+        );
+    }
+
+    /**
+     * 조회 권한 검증
+     * - MANAGER/MASTER: 모든 리뷰 조회 가능
+     * - OWNER: 본인 가게 리뷰만 조회 가능 (TODO: storeId 검증)
+     * - CUSTOMER: 본인이 작성한 리뷰만 조회 가능
+     */
+    private void validateReadPermission(Long userId, UserRoleEnum role, Review review) {
+        // 관리자는 모든 리뷰 조회 가능
+        if (role == UserRoleEnum.MANAGER || role == UserRoleEnum.MASTER) {
+            log.debug("[REVIEW] 관리자 권한으로 조회 - userId: {}, role: {}", userId, role);
+            return;
+        }
+
+        // OWNER는 본인 가게 리뷰만 조회 가능
+        if (role == UserRoleEnum.OWNER) {
+            // TODO(#68): Store 연관관계 추가 후 구현
+            User owner = userService.getUserById(userId);
+            // if (review.getStore().getOwner().getUserId().equals(userId)) { return; }
+            log.debug("[REVIEW] OWNER 조회 권한 검증 (미구현) - userId: {}", userId);
+            return;
+        }
+
+        // 일반 사용자는 본인 리뷰만 조회 가능
+        if (!review.getUser().getUserId().equals(userId)) {
+            log.warn("[REVIEW] 조회 권한 없음 - userId: {}, reviewOwnerId: {}",
+                    userId, review.getUser().getUserId());
+            throw new BusinessException(ErrorCode.REVIEW_READ_FORBIDDEN);
+        }
+
+        log.debug("[REVIEW] 본인 리뷰 조회 - userId: {}", userId);
+    }
+
     @Override
     @Transactional
     public ReviewRes updateReview(Long userId, UUID reviewId, ReviewUpdateReq request) {

--- a/src/main/java/com/delivery/global/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/global/exception/ErrorCode.java
@@ -40,12 +40,13 @@ public enum ErrorCode {
     AI_UNSUPPORTED_REQUEST_TYPE(HttpStatus.BAD_REQUEST, "AI003", "지원하지 않는 요청 타입입니다."),
     AI_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "AI004", "AI 요청 기록을 찾을 수 없습니다."),
 
-    // 리뷰 도메인
+    // Review 도메인
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰를 찾을 수 없습니다."),
     REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "R002", "이미 해당 주문에 대한 리뷰가 작성되었습니다."),
     REVIEW_ORDER_NOT_OWNED(HttpStatus.FORBIDDEN, "R003", "본인의 주문에 대해서만 리뷰를 작성할 수 있습니다."),
+    REVIEW_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "R004", "리뷰를 삭제할 권한이 없습니다."),
 
-    // 주문 도메인
+    // Order 도메인
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "O001", "주문을 찾을 수 없습니다."),
     ORDER_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "O002", "배송이 완료된 주문만 리뷰 작성이 가능합니다."),
 

--- a/src/main/java/com/delivery/global/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/global/exception/ErrorCode.java
@@ -44,7 +44,9 @@ public enum ErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰를 찾을 수 없습니다."),
     REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "R002", "이미 해당 주문에 대한 리뷰가 작성되었습니다."),
     REVIEW_ORDER_NOT_OWNED(HttpStatus.FORBIDDEN, "R003", "본인의 주문에 대해서만 리뷰를 작성할 수 있습니다."),
-    REVIEW_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "R004", "리뷰를 삭제할 권한이 없습니다."),
+    REVIEW_READ_FORBIDDEN(HttpStatus.FORBIDDEN, "R004", "리뷰 조회 권한이 없습니다."),
+    REVIEW_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "R005", "본인이 작성한 리뷰만 수정할 수 있습니다."),
+    REVIEW_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "R006", "리뷰 삭제 권한이 없습니다."),
 
     // Order 도메인
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "O001", "주문을 찾을 수 없습니다."),


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #80  
Close #81  
Close #82 

## 📝 개요
- 리뷰 **조회 / 수정 / 삭제 API**를 구현했습니다.  
- 삭제는 Soft Delete 방식으로 처리합니다.
- 수정은 **작성자 본인만** 가능합니다.

## 🔁 변경 사항
- `GET /api/v1/reviews/{reviewId}` 조회 API 추가  
- `PUT /api/v1/reviews/{reviewId}` 수정 API 추가  
- `DELETE /api/v1/reviews/{reviewId}` 삭제 API 추가  
- 권한 검증 로직 및 관련 ErrorCode 추가  

## 👀 참고 사항
- CUSTOMER: 본인만 수정·삭제 가능  
- MANAGER / MASTER: 전체 조회·삭제 가능  
- HTTP Status  
  - 조회·수정: 200 OK  
  - 삭제: 204 No Content

## 👀 기타