### PR TITLE
feat/#78/get-ai-request-api 

### DIFF
--- a/src/main/java/com/delivery/domain/ai/controller/AiController.java
+++ b/src/main/java/com/delivery/domain/ai/controller/AiController.java
@@ -41,6 +41,22 @@ public class AiController {
     }
 
     /**
+     * AI 요청 기록 단건 조회 API
+     * 권한: MASTER / MANAGER / OWNER (OWNER는 본인이 생성한 기록만)
+     * 응답: 200 OK + ApiResponse<AiRes>
+     */
+    @GetMapping("/{aiId}")
+    @PreAuthorize("hasAnyRole('MASTER','MANAGER','OWNER')")
+    public ResponseEntity<ApiResponse<AiRes>> getAi(
+            @PathVariable UUID aiId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        AiRes response = aiService.getAi(userDetails.getUserId(), userDetails.getRole(), aiId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
      * AI 요청 기록 논리 삭제 (Soft Delete) API
      * 권한: MASTER / MANAGER / OWNER (OWNER는 본인 기록만)
      * 응답: 204 No Content

--- a/src/main/java/com/delivery/domain/ai/service/AiService.java
+++ b/src/main/java/com/delivery/domain/ai/service/AiService.java
@@ -11,5 +11,9 @@ public interface AiService {
     // AI 설명 생성 및 기록
     AiRes createAiContent(Long userId, AiCreateReq request);
 
+    // AI 기록 단건 조회
+    AiRes getAi(Long userId, UserRoleEnum role, UUID aiId);
+
+    // AI 기록 삭제
     void softDelete(UUID aiId, Long userId, UserRoleEnum role);
 }

--- a/src/main/java/com/delivery/domain/ai/service/AiServiceImpl.java
+++ b/src/main/java/com/delivery/domain/ai/service/AiServiceImpl.java
@@ -69,6 +69,31 @@ public class AiServiceImpl implements AiService {
         return AiRes.from(savedAi, userId, menu.getMenuId());
     }
 
+    // AI 요청 기록 단건 조회
+    @Override
+    public AiRes getAi(Long userId, UserRoleEnum role, UUID aiId) {
+        log.info("[AI] 조회 시작 - aiId: {}, userId: {}, role: {}", aiId, userId, role);
+
+        // 미삭제 건만 조회
+        Ai ai = getActiveAi(aiId);
+
+        // 조회 권한 검증 (OWNER는 본인이 생성한 것만, MANAGER/MASTER는 전체 허용)
+        checkReadPermission(userId, role, ai);
+
+        log.info("[AI] 조회 완료 - aiId: {}", aiId);
+        return AiRes.from(ai, userId, ai.getMenu().getMenuId());
+    }
+
+    // AI 조회 권한 검증 (OWNER는 본인이 생성한 것만, MANAGER/MASTER는 전체 허용)
+    private void checkReadPermission(Long userId, UserRoleEnum role, Ai ai) {
+        validateRole(
+                role,
+                userId,
+                ai.getUser().getUserId(),
+                ErrorCode.AI_ACCESS_DENIED
+        );
+    }
+
     // AI 요청 기록 논리 삭제
     @Override
     @Transactional

--- a/src/main/java/com/delivery/global/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/global/exception/ErrorCode.java
@@ -41,7 +41,8 @@ public enum ErrorCode {
     AI_UNSUPPORTED_REQUEST_TYPE(HttpStatus.BAD_REQUEST, "AI003", "지원하지 않는 요청 타입입니다."),
     AI_NOT_FOUND(HttpStatus.NOT_FOUND, "AI004", "AI 요청 기록을 찾을 수 없습니다."),
     AI_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "AI005", "AI 요청 기록을 삭제할 권한이 없습니다."),
-  
+    AI_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AI_006", "AI 요청 기록 조회 권한이 없습니다."),
+
     // 리뷰 도메인
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰를 찾을 수 없습니다."),
     REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "R002", "이미 해당 주문에 대한 리뷰가 작성되었습니다."),


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #78 

## 📝 개요
- AI 기록 단건 조회 API를 구현했습니다.  
- OWNER는 본인 요청만 조회 가능하며, MANAGER / MASTER는 전체 접근 가능합니다.  

## 🔁 변경 사항
- `GET /api/v1/ai/{aiId}` AI 기록 단건 조회 API
- `AiService.getAiById()` 구현  
- 접근 권한 검증 로직 추가  (ErrorCode 추가)
  - OWNER: 본인 요청만 조회 가능  
  - MANAGER / MASTER: 전체 접근 가능  

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 👀 기타