### PR TITLE
Feat/#136/store service area limit

### DIFF
--- a/src/main/java/com/delivery/domain/store/controller/StoreController.java
+++ b/src/main/java/com/delivery/domain/store/controller/StoreController.java
@@ -96,6 +96,11 @@ public class StoreController {
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
+    // 가게 단건 조회
+    @GetMapping("/{storeId}")
+    public ResponseEntity<ApiResponse<StoreRes>> getStore(@PathVariable UUID storeId){
+        return ResponseEntity.ok(ApiResponse.success(storeService.getStore(storeId)));
+    }
 
 
 

--- a/src/main/java/com/delivery/domain/store/dto/StoreCreateReq.java
+++ b/src/main/java/com/delivery/domain/store/dto/StoreCreateReq.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
@@ -25,6 +26,12 @@ public class StoreCreateReq {
 
     @NotBlank(message = "동은 필수입니다.")
     private String dong;
+
+    @NotNull(message = "위도는 필수입니다.")
+    private BigDecimal latitude;
+
+    @NotNull(message = "경도는 필수입니다.")
+    private BigDecimal longitude;
 
     @NotNull(message = "최소 주문 금액은 필수입니다.")
     private Integer minPrice;

--- a/src/main/java/com/delivery/domain/store/dto/StoreUpdateReq.java
+++ b/src/main/java/com/delivery/domain/store/dto/StoreUpdateReq.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
@@ -26,6 +27,12 @@ public class StoreUpdateReq {
 
     @NotBlank(message = "동은 필수입니다.")
     private String dong;
+
+    @NotNull(message = "위도는 필수입니다.")
+    private BigDecimal latitude;
+
+    @NotNull(message = "경도는 필수입니다.")
+    private BigDecimal longitude;
 
     @NotNull(message = "최소 주문 금액은 필수입니다.")
     private Integer minPrice;

--- a/src/main/java/com/delivery/domain/store/entity/Store.java
+++ b/src/main/java/com/delivery/domain/store/entity/Store.java
@@ -4,6 +4,8 @@ import com.delivery.domain.user.entity.User;
 import com.delivery.global.common.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Entity
@@ -33,6 +35,12 @@ public class Store extends Timestamped {
     @Column(nullable = false, length = 50)
     private String dong;
 
+    @Column(nullable = false, precision = 9, scale = 6)
+    private BigDecimal latitude;
+
+    @Column(nullable = false, precision = 9, scale = 6)
+    private BigDecimal longitude;
+
     @Column(nullable = false)
     private Integer minPrice;
 
@@ -61,6 +69,8 @@ public class Store extends Timestamped {
             String city,
             String district,
             String dong,
+            BigDecimal latitude,
+            BigDecimal longitude,
             Integer minPrice,
             User owner
     ){
@@ -70,6 +80,8 @@ public class Store extends Timestamped {
         this.city = city;
         this.district = district;
         this.dong = dong;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.minPrice = minPrice;
         this.owner = owner;
         this.status = StoreStatusEnum.ACTIVE;
@@ -82,6 +94,8 @@ public class Store extends Timestamped {
                        String city,
                        String district,
                        String dong,
+                       BigDecimal latitude,
+                       BigDecimal longitude,
                        Integer minPrice,
                        StoreStatusEnum status) {
         if (name != null) this.name = name;
@@ -90,6 +104,8 @@ public class Store extends Timestamped {
         if (city != null) this.city = city;
         if (district != null) this.district = district;
         if (dong != null) this.dong = dong;
+        if (latitude != null) this.latitude = latitude;
+        if (longitude != null) this.longitude = longitude;
         if (minPrice != null) this.minPrice = minPrice;
         if (status != null) this.status = status;
     }

--- a/src/main/java/com/delivery/domain/store/service/StoreService.java
+++ b/src/main/java/com/delivery/domain/store/service/StoreService.java
@@ -32,7 +32,11 @@ public interface StoreService {
     // 가게 검색 및 조회
     Page<StoreRes> getAllStores(StoreSearchCondition cond, Pageable pageable);
 
+    // 가게 단건 조회
+    StoreRes getStore(UUID storeId);
+
     Store getByStoreIdAndStatus(UUID id, StoreStatusEnum storeStatusEnum);
+
 
 
 

--- a/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
@@ -141,7 +141,7 @@ public class StoreServiceImpl implements StoreService {
         return stores.map(StoreRes::from);
     }
 
-    // 가게 검색 및 조회
+    // 가게 검색 및 목록 조회
     @Override
     public Page<StoreRes> getAllStores(StoreSearchCondition cond, Pageable pageable){
 
@@ -230,5 +230,13 @@ public class StoreServiceImpl implements StoreService {
                     cb.isTrue(category.get("isActive"))
             );
         };
+    }
+
+    // 가게 단건 조회
+    @Override
+    public StoreRes getStore(UUID storeId){
+        Store store = storeRepository.findByStoreIdAndStatus(storeId, StoreStatusEnum.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+        return new StoreRes(store);
     }
 }

--- a/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
@@ -261,16 +261,27 @@ public class StoreServiceImpl implements StoreService {
             throw new BusinessException(ErrorCode.OUT_OF_SERVICE_AREA);
         }
 
-        // 광화문의 위도,경도와 가게 좌표의 거리 계산
-        double distKm = haversineKm(
-                store.getLatitude().doubleValue(),
-                store.getLongitude().doubleValue(),
-                centerLat, centerLon
-        );
+        // 반경(km)을 위도 단위로 환산
+        double latDelta = radiusKm / 111.0;
 
-        if(distKm>radiusKm){
-            throw new BusinessException(ErrorCode.OUT_OF_SERVICE_AREA);
-        }
+        // 경도는 위도에 따른 거리 차이 때문에 cos(위도)로 보정
+        double lonDelta = radiusKm / (111.0 * Math.cos(Math.toRadians(centerLat)));
+
+        // 중심점 기준으로 동,서,남,북 경계 좌표 계산
+        BigDecimal minLat = bd(centerLat - latDelta);
+        BigDecimal maxLat = bd(centerLat + latDelta);
+        BigDecimal minLon = bd(centerLon - lonDelta);
+        BigDecimal maxLon = bd(centerLon + lonDelta);
+
+        BigDecimal lat = store.getLatitude();
+        BigDecimal lon = store.getLongitude();
+
+        // 가게 단건 조회 -> 광화문 근방 바운딩 박스
+        boolean inBox =
+                lat.compareTo(minLat) >= 0 && lat.compareTo(maxLat) <= 0 &&
+                        lon.compareTo(minLon) >= 0 && lon.compareTo(maxLon) <= 0;
+
+        if (!inBox) throw new BusinessException(ErrorCode.OUT_OF_SERVICE_AREA);
 
         return new StoreRes(store);
     }
@@ -302,25 +313,4 @@ public class StoreServiceImpl implements StoreService {
                 );
     }
 
-    // 가게 단건 조회 -> 광화문 근방 구면 거리
-    private double haversineKm(double lat1, double lon1, double lat2, double lon2) {
-
-        // 지구 평균 반지름
-        double R = 6371.0088;
-
-        // 위도와 경도 차이를 radian으로 변환
-        double dLat = Math.toRadians(lat2 - lat1);
-        double dLon = Math.toRadians(lon2 - lon1);
-
-        // Haversine 공식 적용
-        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-                Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
-                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
-
-        // 중심각 계산
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-
-        // 실제 거리 반환
-        return R * c;
-    }
 }

--- a/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
@@ -15,6 +15,7 @@ import com.delivery.global.exception.BusinessException;
 import com.delivery.global.exception.ErrorCode;
 import jakarta.persistence.criteria.Join;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -34,6 +35,16 @@ public class StoreServiceImpl implements StoreService {
     private final StoreRepository storeRepository;
     private final StoreCategoryRepository storeCategoryRepository;
 
+    //광화문 중심좌표/반경 설정값 주입
+    @Value("${app.service-area.center-lat}")
+    private double centerLat;
+
+    @Value("${app.service-area.center-lon}")
+    private double centerLon;
+
+    @Value("${app.service-area.radius-km}")
+    private double radiusKm;
+
     // OWNER, MASTER, MANAGER - 가게 생성
     @Override
     @Transactional
@@ -52,6 +63,8 @@ public class StoreServiceImpl implements StoreService {
                 requestDto.getCity(),
                 requestDto.getDistrict(),
                 requestDto.getDong(),
+                requestDto.getLatitude(),
+                requestDto.getLongitude(),
                 requestDto.getMinPrice(),
                 user
         );
@@ -84,6 +97,8 @@ public class StoreServiceImpl implements StoreService {
                 requestDto.getCity(),
                 requestDto.getDistrict(),
                 requestDto.getDong(),
+                requestDto.getLatitude(),
+                requestDto.getLongitude(),
                 requestDto.getMinPrice(),
                 requestDto.getStatus()
         );
@@ -152,7 +167,8 @@ public class StoreServiceImpl implements StoreService {
                 cityLike(cond.getCity()),
                 districtLike(cond.getDistrict()),
                 dongLike(cond.getDong()),
-                categoryIdLike(cond.getCategoryId())
+                categoryIdLike(cond.getCategoryId()),
+                withinGwangHwaMoon(centerLat, centerLon, radiusKm)
         );
 
         Page<Store> stores = storeRepository.findAll(spec, pageable);
@@ -237,6 +253,68 @@ public class StoreServiceImpl implements StoreService {
     public StoreRes getStore(UUID storeId){
         Store store = storeRepository.findByStoreIdAndStatus(storeId, StoreStatusEnum.ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+
+        // 좌표없으면 차단
+        if(store.getLatitude()==null || store.getLongitude()==null){
+            throw new BusinessException(ErrorCode.OUT_OF_SERVICE_AREA);
+        }
+
+        // 광화문의 위도,경도와 가게 좌표의 거리 계산
+        double distKm = haversineKm(
+                store.getLatitude().doubleValue(),
+                store.getLongitude().doubleValue(),
+                centerLat, centerLon
+        );
+
+        if(distKm>radiusKm){
+            throw new BusinessException(ErrorCode.OUT_OF_SERVICE_AREA);
+        }
+
         return new StoreRes(store);
+    }
+
+    // 가게 목록 조회 -> 광화문 근방 바운딩 박스
+    public Specification<Store> withinGwangHwaMoon(double centerLat, double centerLon, double radiusKm){
+
+        // 반경(km)을 위도 단위로 환산
+        double latDelta = radiusKm / 111.0;
+
+        // 경도는 위도에 따른 거리 차이 때문에 cos(위도)로 보정
+        double lonDelta = radiusKm / (111.0 * Math.cos(Math.toRadians(centerLat)));
+
+        // 중심점 기준으로 동,서,남,북 경계 좌표 계산
+        double minLat = centerLat - latDelta;
+        double maxLat = centerLat + latDelta;
+        double minLon = centerLon - lonDelta;
+        double maxLon = centerLon + lonDelta;
+
+        return (root, query, cb) -> cb.and(
+                cb.isNotNull(root.get("latitude")),
+                cb.isNotNull(root.get("longitude")),
+                cb.between(root.get("latitude"), minLat, maxLat),
+                cb.between(root.get("longitude"), minLon, maxLon)
+                );
+    }
+
+    // 가게 단건 조회 -> 광화문 근방 구면 거리
+    private double haversineKm(double lat1, double lon1, double lat2, double lon2) {
+
+        // 지구 평균 반지름
+        double R = 6371.0088;
+
+        // 위도와 경도 차이를 radian으로 변환
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        // Haversine 공식 적용
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
+                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        // 중심각 계산
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        // 실제 거리 반환
+        return R * c;
     }
 }

--- a/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
@@ -23,6 +23,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
@@ -273,6 +275,10 @@ public class StoreServiceImpl implements StoreService {
         return new StoreRes(store);
     }
 
+    private static BigDecimal bd(double v) {
+        return BigDecimal.valueOf(v).setScale(6, RoundingMode.HALF_UP);
+    }
+
     // 가게 목록 조회 -> 광화문 근방 바운딩 박스
     public Specification<Store> withinGwangHwaMoon(double centerLat, double centerLon, double radiusKm){
 
@@ -283,10 +289,10 @@ public class StoreServiceImpl implements StoreService {
         double lonDelta = radiusKm / (111.0 * Math.cos(Math.toRadians(centerLat)));
 
         // 중심점 기준으로 동,서,남,북 경계 좌표 계산
-        double minLat = centerLat - latDelta;
-        double maxLat = centerLat + latDelta;
-        double minLon = centerLon - lonDelta;
-        double maxLon = centerLon + lonDelta;
+        BigDecimal minLat = bd(centerLat - latDelta);
+        BigDecimal maxLat = bd(centerLat + latDelta);
+        BigDecimal minLon = bd(centerLon - lonDelta);
+        BigDecimal maxLon = bd(centerLon + lonDelta);
 
         return (root, query, cb) -> cb.and(
                 cb.isNotNull(root.get("latitude")),

--- a/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
@@ -261,25 +261,14 @@ public class StoreServiceImpl implements StoreService {
             throw new BusinessException(ErrorCode.OUT_OF_SERVICE_AREA);
         }
 
-        // 반경(km)을 위도 단위로 환산
-        double latDelta = radiusKm / 111.0;
-
-        // 경도는 위도에 따른 거리 차이 때문에 cos(위도)로 보정
-        double lonDelta = radiusKm / (111.0 * Math.cos(Math.toRadians(centerLat)));
-
-        // 중심점 기준으로 동,서,남,북 경계 좌표 계산
-        BigDecimal minLat = bd(centerLat - latDelta);
-        BigDecimal maxLat = bd(centerLat + latDelta);
-        BigDecimal minLon = bd(centerLon - lonDelta);
-        BigDecimal maxLon = bd(centerLon + lonDelta);
-
+        BoundingBox box = getBoundingBox(centerLat, centerLon, radiusKm);
         BigDecimal lat = store.getLatitude();
         BigDecimal lon = store.getLongitude();
 
         // 가게 단건 조회 -> 광화문 근방 바운딩 박스
         boolean inBox =
-                lat.compareTo(minLat) >= 0 && lat.compareTo(maxLat) <= 0 &&
-                        lon.compareTo(minLon) >= 0 && lon.compareTo(maxLon) <= 0;
+                lat.compareTo(box.minLat) >= 0 && lat.compareTo(box.maxLat) <= 0 &&
+                        lon.compareTo(box.minLon) >= 0 && lon.compareTo(box.maxLon) <= 0;
 
         if (!inBox) throw new BusinessException(ErrorCode.OUT_OF_SERVICE_AREA);
 
@@ -293,24 +282,32 @@ public class StoreServiceImpl implements StoreService {
     // 가게 목록 조회 -> 광화문 근방 바운딩 박스
     public Specification<Store> withinGwangHwaMoon(double centerLat, double centerLon, double radiusKm){
 
+        BoundingBox box = getBoundingBox(centerLat, centerLon, radiusKm);
+
+        return (root, query, cb) -> cb.and(
+                cb.isNotNull(root.get("latitude")),
+                cb.isNotNull(root.get("longitude")),
+                cb.between(root.get("latitude"), box.minLat(), box.maxLat()),
+                cb.between(root.get("longitude"), box.maxLon(), box.maxLon())
+                );
+    }
+
+    // 바운딩박스 로직 통합
+    private BoundingBox getBoundingBox(double centerLat, double centerLon, double radiusKm){
+
         // 반경(km)을 위도 단위로 환산
         double latDelta = radiusKm / 111.0;
 
         // 경도는 위도에 따른 거리 차이 때문에 cos(위도)로 보정
         double lonDelta = radiusKm / (111.0 * Math.cos(Math.toRadians(centerLat)));
 
-        // 중심점 기준으로 동,서,남,북 경계 좌표 계산
-        BigDecimal minLat = bd(centerLat - latDelta);
-        BigDecimal maxLat = bd(centerLat + latDelta);
-        BigDecimal minLon = bd(centerLon - lonDelta);
-        BigDecimal maxLon = bd(centerLon + lonDelta);
-
-        return (root, query, cb) -> cb.and(
-                cb.isNotNull(root.get("latitude")),
-                cb.isNotNull(root.get("longitude")),
-                cb.between(root.get("latitude"), minLat, maxLat),
-                cb.between(root.get("longitude"), minLon, maxLon)
-                );
+        return new BoundingBox(
+                bd(centerLat - latDelta),
+                bd(centerLat + latDelta),
+                bd(centerLon - lonDelta),
+                bd(centerLon + lonDelta)
+        );
     }
+    record BoundingBox(BigDecimal minLat, BigDecimal maxLat, BigDecimal minLon, BigDecimal maxLon) {}
 
 }

--- a/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/delivery/domain/store/service/StoreServiceImpl.java
@@ -44,7 +44,7 @@ public class StoreServiceImpl implements StoreService {
     @Value("${app.service-area.center-lon}")
     private double centerLon;
 
-    @Value("${app.service-area.radius-km}")
+    @Value("${app.service-area.radius-km:3.0}")
     private double radiusKm;
 
     // OWNER, MASTER, MANAGER - 가게 생성
@@ -250,7 +250,24 @@ public class StoreServiceImpl implements StoreService {
         };
     }
 
-    // 가게 단건 조회
+    private static BigDecimal bd(double v) {
+        return BigDecimal.valueOf(v).setScale(6, RoundingMode.HALF_UP);
+    }
+
+    // 가게 목록 조회 -> 광화문 근방 바운딩 박스
+    public Specification<Store> withinGwangHwaMoon(double centerLat, double centerLon, double radiusKm){
+
+        BoundingBox box = getBoundingBox(centerLat, centerLon, radiusKm);
+
+        return (root, query, cb) -> cb.and(
+                cb.isNotNull(root.get("latitude")),
+                cb.isNotNull(root.get("longitude")),
+                cb.between(root.get("latitude"), box.minLat(), box.maxLat()),
+                cb.between(root.get("longitude"), box.minLon(), box.maxLon())
+        );
+    }
+
+    // 가게 단건 조회 -> 광화문 근방 바운딩 박스
     @Override
     public StoreRes getStore(UUID storeId){
         Store store = storeRepository.findByStoreIdAndStatus(storeId, StoreStatusEnum.ACTIVE)
@@ -265,31 +282,14 @@ public class StoreServiceImpl implements StoreService {
         BigDecimal lat = store.getLatitude();
         BigDecimal lon = store.getLongitude();
 
-        // 가게 단건 조회 -> 광화문 근방 바운딩 박스
+        // 광화문 근방 바운딩 박스 검증
         boolean inBox =
-                lat.compareTo(box.minLat) >= 0 && lat.compareTo(box.maxLat) <= 0 &&
-                        lon.compareTo(box.minLon) >= 0 && lon.compareTo(box.maxLon) <= 0;
+                box.minLat().compareTo(lat) <= 0 && lat.compareTo(box.maxLat()) <= 0 &&
+                        box.minLon().compareTo(lon) <= 0 && lon.compareTo(box.maxLon()) <= 0;
 
         if (!inBox) throw new BusinessException(ErrorCode.OUT_OF_SERVICE_AREA);
 
         return new StoreRes(store);
-    }
-
-    private static BigDecimal bd(double v) {
-        return BigDecimal.valueOf(v).setScale(6, RoundingMode.HALF_UP);
-    }
-
-    // 가게 목록 조회 -> 광화문 근방 바운딩 박스
-    public Specification<Store> withinGwangHwaMoon(double centerLat, double centerLon, double radiusKm){
-
-        BoundingBox box = getBoundingBox(centerLat, centerLon, radiusKm);
-
-        return (root, query, cb) -> cb.and(
-                cb.isNotNull(root.get("latitude")),
-                cb.isNotNull(root.get("longitude")),
-                cb.between(root.get("latitude"), box.minLat(), box.maxLat()),
-                cb.between(root.get("longitude"), box.maxLon(), box.maxLon())
-                );
     }
 
     // 바운딩박스 로직 통합

--- a/src/main/java/com/delivery/global/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     FORBIDDEN_UPDATE_STORE(HttpStatus.FORBIDDEN, "S003", "가게를 수정할 권한이 없습니다."),
     FORBIDDEN_DELETE_STORE(HttpStatus.FORBIDDEN, "S004", "가게를 삭제할 권한이 없습니다."),
     FORBIDDEN_READ_STORE(HttpStatus.FORBIDDEN,"s005", "가게를 조회할 권한이 없습니다." ),
+    OUT_OF_SERVICE_AREA(HttpStatus.FORBIDDEN,"S006","서비스 가능 지역 외 요청입니다." ),
 
     // jwt
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "A001", "토큰이 존재하지 않습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,11 +14,16 @@ spring:
     hibernate:
       ddl-auto: create
     show-sql: true
+    defer-datasource-initialization: true
     properties:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+  sql:
+    init:
+      mode: always
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,52 @@
+spring:
+  config:
+    import: optional:file:./.env[.properties]
+  application:
+    name: delivery
+  
+  datasource:
+    url: ${POSTGRES_URL}
+    username: ${POSTGRES_USERNAME}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.springframework.orm.jpa: DEBUG
+    org.springframework.transaction: DEBUG
+
+jwt:
+  secret:
+    key: asdfadkfkjdkfjkfddjfkjakjadjfaksfdjksfjksdjfksghjdksfjasksgjasdfjsdffjkskffj
+  access-token:
+    expire-time: 1800000
+  refresh-token:
+    expire-time: 604800000
+
+ai:
+  gemini:
+    api-key: ${GOOGLE_API_KEY}
+    model: gemini-2.5-flash
+    max-output-tokens: 100
+    temperature: 0.7
+    prompt-suffix: " 답변을 최대한 간결하게 50자 이하로"
+
+
+app:
+  service-area:
+    center-lat: 37.5760222
+    center-lon: 126.9769000
+    radius-km: 3.0
+

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,34 @@
+
+INSERT INTO p_store_category (category_id, category_name, is_active, created_at, modified_at)
+SELECT '11111111-1111-1111-1111-111111111111', '한식', TRUE, now(), now()
+    WHERE NOT EXISTS (
+  SELECT 1 FROM p_store_category WHERE category_name = '한식'
+);
+
+
+INSERT INTO p_store_category (category_id, category_name, is_active, created_at, modified_at)
+SELECT '22222222-2222-2222-2222-222222222222', '중식', TRUE, now(), now()
+    WHERE NOT EXISTS (
+  SELECT 1 FROM p_store_category WHERE category_name = '중식'
+);
+
+
+INSERT INTO p_store_category (category_id, category_name, is_active, created_at, modified_at)
+SELECT '33333333-3333-3333-3333-333333333333', '분식', TRUE, now(), now()
+    WHERE NOT EXISTS (
+  SELECT 1 FROM p_store_category WHERE category_name = '분식'
+);
+
+
+INSERT INTO p_store_category (category_id, category_name, is_active, created_at, modified_at)
+SELECT '44444444-4444-4444-4444-444444444444', '치킨', TRUE, now(), now()
+    WHERE NOT EXISTS (
+  SELECT 1 FROM p_store_category WHERE category_name = '치킨'
+);
+
+
+INSERT INTO p_store_category (category_id, category_name, is_active, created_at, modified_at)
+SELECT '55555555-5555-5555-5555-555555555555', '피자', TRUE, now(), now()
+    WHERE NOT EXISTS (
+  SELECT 1 FROM p_store_category WHERE category_name = '피자'
+);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #136

## 📝 개요
- 전국 단위로 동작하던 가게 검색/조회 로직에 서비스 가능 지역(광화문 중심 bbox 3km) 제한 기능을 추가했습니다.
- 서비스 기능 반경 밖의 가게는 목록 조회, 단건 조회 시 표시되지 않습니다.

## 🔁 변경 사항
- Store 엔티티에 latitude, longtitude(위도, 경도) 필드 추가
- Store 생성/수정 DTO에 위경도 필수값 반영
- application.yml에 광화문 중심 좌표 및 서비스 반경 설정 추가
 ```
app:
  service-area:
    center-lat: 37.5760222   
    center-lon: 126.9769000
    radius-km: 3.0
```
- ErrorCode 추가

## 👀 참고 사항
- Store 목록 조회 시 `getBoundingBox` 이용해서 `withinGwangHwaMoon()` Specification으로 검증
- Store 단건 조회 시 `getBoundingBox` 이용해서 내부 로직으로 검증

## 👀 기타