### PR TITLE
feat/#79/search ai request api

### DIFF
--- a/src/main/java/com/delivery/domain/ai/controller/AiController.java
+++ b/src/main/java/com/delivery/domain/ai/controller/AiController.java
@@ -2,11 +2,15 @@ package com.delivery.domain.ai.controller;
 
 import com.delivery.domain.ai.dto.AiCreateReq;
 import com.delivery.domain.ai.dto.AiRes;
+import com.delivery.domain.ai.dto.AiSearchRes;
+import com.delivery.domain.ai.entity.RequestTypeEnum;
 import com.delivery.domain.ai.service.AiService;
 import com.delivery.global.common.ApiResponse;
 import com.delivery.global.security.service.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -70,5 +74,31 @@ public class AiController {
         aiService.softDelete(aiId, userDetails.getUserId(), userDetails.getRole());
 
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * AI 요청 기록 검색 API
+     * - 기본 정렬: createdAt DESC
+     * - 페이지 크기: 10, 30, 50만 허용 (기타 값은 10으로 강제)
+     * - 권한: OWNER는 본인 데이터만, MANAGER/MASTER는 전체 조회
+     */
+    @GetMapping("/search")
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    public ResponseEntity<ApiResponse<Page<AiSearchRes>>> searchAiRequests(
+            @RequestParam(required = false) RequestTypeEnum requestType,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) UUID menuId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "DESC") Sort.Direction direction,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        Page<AiSearchRes> result = aiService.searchAiRequests(
+                requestType, userId, menuId,
+                page, size, direction,
+                userDetails.getUser()
+        );
+
+        return  ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/delivery/domain/ai/dto/AiSearchRes.java
+++ b/src/main/java/com/delivery/domain/ai/dto/AiSearchRes.java
@@ -1,0 +1,39 @@
+package com.delivery.domain.ai.dto;
+
+import com.delivery.domain.ai.entity.Ai;
+import com.delivery.domain.ai.entity.RequestTypeEnum;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class AiSearchRes {
+    private UUID aiId;
+    private Long userId;
+    private String nickname;
+    private UUID menuId;
+    private String menuName;
+    private RequestTypeEnum requestType;
+    private String prompt;
+    private String response;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static AiSearchRes from(Ai ai) {
+        return AiSearchRes.builder()
+                .aiId(ai.getAiId())
+                .userId(ai.getUser().getUserId())
+                .nickname(ai.getUser().getNickname())
+                .menuId(ai.getMenu().getMenuId())
+                .menuName(ai.getMenu().getName())
+                .requestType(ai.getRequestType())
+                .prompt(ai.getPrompt())
+                .response(ai.getResponse())
+                .createdAt(ai.getCreatedAt())
+                .updatedAt(ai.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/delivery/domain/ai/repository/AiRepository.java
+++ b/src/main/java/com/delivery/domain/ai/repository/AiRepository.java
@@ -1,6 +1,5 @@
 package com.delivery.domain.ai.repository;
 
-import com.delivery.domain.ai.dto.AiSearchRes;
 import com.delivery.domain.ai.entity.Ai;
 import com.delivery.domain.ai.entity.RequestTypeEnum;
 import org.springframework.data.domain.Page;
@@ -33,42 +32,4 @@ public interface AiRepository extends JpaRepository<Ai, UUID> {
              @Param("menuId") UUID menuId,
              Pageable pageable
      );
-//    /**
-//     * 전체 검색 (관리자 전용)
-//     */
-//    @Query("""
-//        SELECT new com.delivery.domain.ai.dto.AiSearchRes(
-//            a.aiId, a.user.userId, a.menu.menuId, a.requestType,
-//            a.prompt, a.response, a.createdAt
-//        )
-//        FROM Ai a
-//        WHERE a.deletedAt IS NULL
-//          AND (:requestType IS NULL OR a.requestType = :requestType)
-//          AND (:menuId IS NULL OR a.menu.menuId = :menuId)
-//        ORDER BY a.createdAt DESC
-//        """)
-//    Page<AiSearchRes> searchAll(@Param("requestType") RequestTypeEnum requestType,
-//                                @Param("menuId") UUID menuId,
-//                                Pageable pageable);
-//
-//    /**
-//     * 특정 유저 검색 (소유자 or 관리자가 userId 명시한 경우)
-//     */
-//    @Query("""
-//        SELECT new com.delivery.domain.ai.dto.AiSearchRes(
-//            a.aiId, a.user.userId, a.menu.menuId, a.requestType,
-//            a.prompt, a.response, a.createdAt
-//        )
-//        FROM Ai a
-//        WHERE a.deletedAt IS NULL
-//          AND a.user.userId = :userId
-//          AND (:requestType IS NULL OR a.requestType = :requestType)
-//          AND (:menuId IS NULL OR a.menu.menuId = :menuId)
-//        ORDER BY a.createdAt DESC
-//        """)
-//    Page<AiSearchRes> searchByUserId(@Param("requestType") RequestTypeEnum requestType,
-//                                     @Param("userId") Long userId,
-//                                     @Param("menuId") UUID menuId,
-//                                     Pageable pageable);
-
 }

--- a/src/main/java/com/delivery/domain/ai/repository/AiRepository.java
+++ b/src/main/java/com/delivery/domain/ai/repository/AiRepository.java
@@ -1,7 +1,13 @@
 package com.delivery.domain.ai.repository;
 
+import com.delivery.domain.ai.dto.AiSearchRes;
 import com.delivery.domain.ai.entity.Ai;
+import com.delivery.domain.ai.entity.RequestTypeEnum;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -10,4 +16,59 @@ public interface AiRepository extends JpaRepository<Ai, UUID> {
 
     // 삭제되지 않은 AI 기록 조회
     Optional<Ai> findByAiIdAndDeletedAtIsNull(UUID aiId);
+
+     // 전체 검색 (모든 조건)
+     @Query("SELECT a FROM Ai a " +
+             "JOIN FETCH a.user u " +
+             "JOIN FETCH a.menu m " +
+             "WHERE (:requestType IS NULL OR a.requestType = :requestType) " +
+             "AND (:userId IS NULL OR u.userId = :userId) " +
+             "AND (:menuId IS NULL OR m.menuId = :menuId) " +
+             "AND a.deletedAt IS NULL " +
+             "AND u.deletedAt IS NULL " +
+             "AND m.deletedAt IS NULL")
+     Page<Ai> searchAiRequests(
+             @Param("requestType") RequestTypeEnum requestType,
+             @Param("userId") Long userId,
+             @Param("menuId") UUID menuId,
+             Pageable pageable
+     );
+//    /**
+//     * 전체 검색 (관리자 전용)
+//     */
+//    @Query("""
+//        SELECT new com.delivery.domain.ai.dto.AiSearchRes(
+//            a.aiId, a.user.userId, a.menu.menuId, a.requestType,
+//            a.prompt, a.response, a.createdAt
+//        )
+//        FROM Ai a
+//        WHERE a.deletedAt IS NULL
+//          AND (:requestType IS NULL OR a.requestType = :requestType)
+//          AND (:menuId IS NULL OR a.menu.menuId = :menuId)
+//        ORDER BY a.createdAt DESC
+//        """)
+//    Page<AiSearchRes> searchAll(@Param("requestType") RequestTypeEnum requestType,
+//                                @Param("menuId") UUID menuId,
+//                                Pageable pageable);
+//
+//    /**
+//     * 특정 유저 검색 (소유자 or 관리자가 userId 명시한 경우)
+//     */
+//    @Query("""
+//        SELECT new com.delivery.domain.ai.dto.AiSearchRes(
+//            a.aiId, a.user.userId, a.menu.menuId, a.requestType,
+//            a.prompt, a.response, a.createdAt
+//        )
+//        FROM Ai a
+//        WHERE a.deletedAt IS NULL
+//          AND a.user.userId = :userId
+//          AND (:requestType IS NULL OR a.requestType = :requestType)
+//          AND (:menuId IS NULL OR a.menu.menuId = :menuId)
+//        ORDER BY a.createdAt DESC
+//        """)
+//    Page<AiSearchRes> searchByUserId(@Param("requestType") RequestTypeEnum requestType,
+//                                     @Param("userId") Long userId,
+//                                     @Param("menuId") UUID menuId,
+//                                     Pageable pageable);
+
 }

--- a/src/main/java/com/delivery/domain/ai/service/AiService.java
+++ b/src/main/java/com/delivery/domain/ai/service/AiService.java
@@ -2,7 +2,12 @@ package com.delivery.domain.ai.service;
 
 import com.delivery.domain.ai.dto.AiCreateReq;
 import com.delivery.domain.ai.dto.AiRes;
+import com.delivery.domain.ai.dto.AiSearchRes;
+import com.delivery.domain.ai.entity.RequestTypeEnum;
+import com.delivery.domain.user.entity.User;
 import com.delivery.domain.user.entity.UserRoleEnum;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 
 import java.util.UUID;
 
@@ -16,4 +21,7 @@ public interface AiService {
 
     // AI 기록 삭제
     void softDelete(UUID aiId, Long userId, UserRoleEnum role);
+
+    // AI 기록 검색
+    Page<AiSearchRes> searchAiRequests(RequestTypeEnum requestType, Long userId, UUID menuId, int page, int size, Sort.Direction direction, User user);
 }

--- a/src/main/java/com/delivery/domain/ai/service/AiServiceImpl.java
+++ b/src/main/java/com/delivery/domain/ai/service/AiServiceImpl.java
@@ -4,6 +4,7 @@ import com.delivery.domain.ai.client.GeminiAiClient;
 import com.delivery.domain.ai.config.GeminiProperties;
 import com.delivery.domain.ai.dto.AiCreateReq;
 import com.delivery.domain.ai.dto.AiRes;
+import com.delivery.domain.ai.dto.AiSearchRes;
 import com.delivery.domain.ai.entity.Ai;
 import com.delivery.domain.ai.entity.RequestTypeEnum;
 import com.delivery.domain.ai.repository.AiRepository;
@@ -14,8 +15,13 @@ import com.delivery.domain.user.entity.UserRoleEnum;
 import com.delivery.domain.user.service.UserService;
 import com.delivery.global.exception.BusinessException;
 import com.delivery.global.exception.ErrorCode;
+import com.delivery.global.util.PageableUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -110,6 +116,56 @@ public class AiServiceImpl implements AiService {
         ai.markDeleted(userId);
 
         log.info("[AI] 삭제 완료 - aiId: {}, deletedBy: {}", aiId, userId);
+    }
+
+    // AI 요청 기록 검색 (페이징)
+    @Override
+    public Page<AiSearchRes> searchAiRequests(
+            RequestTypeEnum requestType,
+            Long userId,
+            UUID menuId,
+            int page,
+            int size,
+            Sort.Direction direction,
+            User currentUser
+    ) {
+        log.info("[AI_SEARCH] 검색 시작 - requesterId={}, role={}," +
+                        " reqType={}, userId={}, menuId={}, page={}, size={}, dir={}",
+                currentUser.getUserId(), currentUser.getRole(), requestType, userId, menuId, page, size, direction);
+
+        // Pageable 생성
+        Pageable pageable = PageableUtils.createPageableWithCreatedAt(page, size, direction);
+
+        // 권한에 따른 userId 결정 (OWNER: 본인 강제, MANAGER/MASTER: 요청 user 또는 전체)
+        Long resolvedUserId = determineSearchUserId(userId, currentUser);
+        log.debug("[AI_SEARCH] 조회 범위 적용 - resolvedUserId={}",
+                resolvedUserId != null ? resolvedUserId : "ALL");
+
+        // 검색 실행 (DB 조회)
+        try {
+            Page<Ai> aiPage = aiRepository.searchAiRequests(requestType, resolvedUserId, menuId, pageable);
+
+            log.info("[AI_SEARCH] 검색 완료 - total={}, pageNo={}",
+                    aiPage.getTotalElements(), aiPage.getNumber());
+
+            return aiPage.map(AiSearchRes::from);
+
+        } catch (DataAccessException dae) {
+            log.error("[AI_SEARCH] DB 조회 실패 - reqType={}, resolvedUserId={}, menuId={}, page={}, size={}, dir={}",
+                    requestType, resolvedUserId, menuId, page, size, direction, dae);
+            throw new BusinessException(ErrorCode.AI_SEARCH_FAILED);
+        }
+    }
+
+    /**
+     * 사용자 역할에 따라 조회 가능한 데이터 범위 제한
+     * - OWNER: 본인 데이터만 조회 (요청 파라미터 무시)
+     * - MANAGER/MASTER: 전체 또는 특정 사용자 조회  가능
+     */
+    private Long determineSearchUserId(Long requestedUserId, User currentUser) {
+        return (currentUser.getRole() == UserRoleEnum.OWNER)
+                ? currentUser.getUserId()
+                : requestedUserId;
     }
 
     // 프롬프트 가공 (요구사항: 50자 이하 안내 문구 첨부)

--- a/src/main/java/com/delivery/global/exception/ErrorCode.java
+++ b/src/main/java/com/delivery/global/exception/ErrorCode.java
@@ -41,7 +41,8 @@ public enum ErrorCode {
     AI_UNSUPPORTED_REQUEST_TYPE(HttpStatus.BAD_REQUEST, "AI003", "지원하지 않는 요청 타입입니다."),
     AI_NOT_FOUND(HttpStatus.NOT_FOUND, "AI004", "AI 요청 기록을 찾을 수 없습니다."),
     AI_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "AI005", "AI 요청 기록을 삭제할 권한이 없습니다."),
-    AI_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AI_006", "AI 요청 기록 조회 권한이 없습니다."),
+    AI_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AI006", "AI 요청 기록 조회 권한이 없습니다."),
+    AI_SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI007", "AI 검색 처리 중 오류가 발생했습니다."),
 
     // 리뷰 도메인
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰를 찾을 수 없습니다."),

--- a/src/main/java/com/delivery/global/util/PageableUtils.java
+++ b/src/main/java/com/delivery/global/util/PageableUtils.java
@@ -1,0 +1,39 @@
+package com.delivery.global.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.Set;
+
+@Slf4j
+public class PageableUtils {
+
+    private static final Set<Integer> ALLOWED_PAGE_SIZES = Set.of(10, 30, 50);
+    private static final int DEFAULT_PAGE_SIZE = 10;
+
+    /**
+     * createdAt 기준 Pageable 생성
+     * @param page 페이지 번호
+     * @param size 페이지 크기 (10, 30, 50만 허용)
+     * @param direction 정렬 방향 (ASC/DESC)
+     */
+    public static Pageable createPageableWithCreatedAt(int page, int size, Sort.Direction direction) {
+        int validatedSize = validatePageSize(size);
+        log.debug("[PAGEABLE] 생성 완료 - page={}, size={}, sort=createdAt, direction={}",
+                page, validatedSize, direction);
+
+        return PageRequest.of(page, validatedSize, Sort.by(direction, "createdAt"));
+    }
+
+    // 페이지 크기 검증: 10, 30, 50 이외는 10으로 강제
+    private static int validatePageSize(int size) {
+        if (!ALLOWED_PAGE_SIZES.contains(size)) {
+            log.warn("[PAGEABLE] 허용되지 않은 페이지 크기 - requested={}, allowed={}, applied={}",
+                    size, ALLOWED_PAGE_SIZES, DEFAULT_PAGE_SIZE);
+            return DEFAULT_PAGE_SIZE;
+        }
+        return size;
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #79 

## 📝 개요
- AI 요청 기록을 **검색/정렬/페이지네이션(Page)** 으로 조회하는 API 구현했습니다.
- 기본 정렬: `createdAt DESC`, 페이지 크기: **10/30/50**만 허용

## 🔁 변경 사항
- `GET /api/v1/ai/search` 추가
  - 조건: `requestType`, `userId`, `menuId`
  - 정렬: `createdAt` + `Sort.Direction`(기본 `DESC`)
  - 페이지 크기: **10/30/50**만 허용(기타는 10으로 강제)
- 권한: OWNER=본인만 / MANAGER·MASTER=전체·특정 사용자 조회
- 관련 `ErrorCode` 추가

## 👀 참고 사항
- Page JSON 안정화(`PagedModel`)는 별도 리팩토링 예정

## 👀 기타